### PR TITLE
Improvement: add dependency injection via Dagger Hilt

### DIFF
--- a/.idea/kotlinc.xml
+++ b/.idea/kotlinc.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="KotlinJpsPluginSettings">
-    <option name="version" value="1.9.0" />
+    <option name="version" value="2.0.0" />
   </component>
 </project>

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -2,7 +2,10 @@ import java.util.Properties
 
 plugins {
     alias(libs.plugins.android.application)
+    alias(libs.plugins.compose.compiler)
     alias(libs.plugins.jetbrains.kotlin.android)
+    alias(libs.plugins.hilt)
+    alias(libs.plugins.ksp)
 }
 
 val appPropertiesFile = rootProject.file("app.properties")
@@ -53,10 +56,6 @@ android {
         compose = true
         buildConfig = true
     }
-
-    composeOptions {
-        kotlinCompilerExtensionVersion = "1.5.1"
-    }
     packaging {
         resources {
             excludes += "/META-INF/{AL2.0,LGPL2.1}"
@@ -84,6 +83,10 @@ dependencies {
     implementation(libs.androidx.ui.tooling.preview)
     implementation(libs.androidx.material3)
     implementation(libs.androidx.lifecycle.runtime.compose.android)
+
+    // Hilt
+    implementation(libs.hilt)
+    ksp(libs.hilt.compiler)
 
     // Retrofit & Moshi
     implementation(libs.retrofit)

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -23,8 +23,8 @@ android {
         applicationId = "com.jogasoft.moviefinder"
         minSdk = 24
         targetSdk = 34
-        versionCode = 2
-        versionName = "0.0.2"
+        versionCode = 3
+        versionName = "0.0.3"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -5,6 +5,7 @@
     <uses-permission android:name="android.permission.INTERNET"/>
 
     <application
+        android:name="com.jogasoft.MovieFinderApplication"
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="@xml/backup_rules"

--- a/app/src/main/java/com/jogasoft/MovieFinderApplication.kt
+++ b/app/src/main/java/com/jogasoft/MovieFinderApplication.kt
@@ -1,0 +1,7 @@
+package com.jogasoft
+
+import android.app.Application
+import dagger.hilt.android.HiltAndroidApp
+
+@HiltAndroidApp
+class MovieFinderApplication: Application()

--- a/app/src/main/java/com/jogasoft/moviefinder/data/DefaultMovieRepository.kt
+++ b/app/src/main/java/com/jogasoft/moviefinder/data/DefaultMovieRepository.kt
@@ -1,0 +1,21 @@
+package com.jogasoft.moviefinder.data
+
+import com.jogasoft.moviefinder.data.source.network.DefaultMovieNetworkDataSource
+import com.jogasoft.moviefinder.data.source.network.model.movie.toMovies
+import kotlinx.coroutines.CancellationException
+import javax.inject.Inject
+
+class DefaultMovieRepository @Inject constructor(
+    private val movieNetworkDataSource: DefaultMovieNetworkDataSource
+) : MovieRepository {
+    override suspend fun getNowPlayingMovies(): Result<List<Movie>> {
+        return try {
+            movieNetworkDataSource.getNowPlayingMovies().fold(
+                onSuccess = { Result.success(it.toMovies()) },
+                onFailure = { Result.failure(it) }
+            )
+        } catch (e: CancellationException) {
+            throw e
+        }
+    }
+}

--- a/app/src/main/java/com/jogasoft/moviefinder/data/MovieRepository.kt
+++ b/app/src/main/java/com/jogasoft/moviefinder/data/MovieRepository.kt
@@ -1,20 +1,5 @@
 package com.jogasoft.moviefinder.data
 
-import com.jogasoft.moviefinder.data.source.network.MovieNetworkDataSource
-import com.jogasoft.moviefinder.data.source.network.model.movie.toMovies
-import kotlinx.coroutines.CancellationException
-
-class MovieRepository {
-    private val movieNetworkDataSource = MovieNetworkDataSource()
-
-    suspend fun getNowPlayingMovies(): Result<List<Movie>> {
-        return try {
-            movieNetworkDataSource.getNowPlayingMovies().fold(
-                onSuccess = { Result.success(it.toMovies()) },
-                onFailure = { Result.failure(it) }
-            )
-        } catch (e: CancellationException) {
-            throw e
-        }
-    }
+interface MovieRepository {
+    suspend fun getNowPlayingMovies(): Result<List<Movie>>
 }

--- a/app/src/main/java/com/jogasoft/moviefinder/data/source/network/DefaultMovieNetworkDataSource.kt
+++ b/app/src/main/java/com/jogasoft/moviefinder/data/source/network/DefaultMovieNetworkDataSource.kt
@@ -1,0 +1,43 @@
+package com.jogasoft.moviefinder.data.source.network
+
+import android.util.Log
+import com.jogasoft.moviefinder.data.source.network.model.movie.NetworkMovie
+import javax.inject.Inject
+import kotlin.coroutines.cancellation.CancellationException
+
+class DefaultMovieNetworkDataSource @Inject constructor(
+    private val movieApi: MovieApi
+): MovieNetworkDataSource {
+
+    override suspend fun getNowPlayingMovies(): Result<List<NetworkMovie>> {
+        return try {
+            val response = movieApi.getNowPlayingMovies()
+            val moviePage = response.body()
+
+            when {
+                response.isSuccessful && moviePage != null -> {
+                    Log.d(TAG, "Now Playing Movie Fetch successful")
+                    Result.success(moviePage.results)
+                }
+                else -> {
+                    Result.failure(
+                        NetworkException(
+                            message = response.errorBody()?.string() ?: "Failed to get Now Playing Movies",
+                            responseCode = response.code(),
+                        )
+                    )
+                }
+            }
+        } catch (e: CancellationException) {
+            Log.e(TAG, "Get Now Playing Movies operation was canceled", e)
+            throw e
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to get Now Playing Movies", e)
+            Result.failure(e)
+        }
+    }
+
+    companion object {
+        private val TAG = DefaultMovieNetworkDataSource::class.java.simpleName
+    }
+}

--- a/app/src/main/java/com/jogasoft/moviefinder/data/source/network/MovieNetworkDataSource.kt
+++ b/app/src/main/java/com/jogasoft/moviefinder/data/source/network/MovieNetworkDataSource.kt
@@ -1,54 +1,7 @@
 package com.jogasoft.moviefinder.data.source.network
 
-import android.util.Log
-import com.jogasoft.moviefinder.BuildConfig
 import com.jogasoft.moviefinder.data.source.network.model.movie.NetworkMovie
-import com.squareup.moshi.Moshi
-import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
-import retrofit2.Retrofit
-import retrofit2.converter.moshi.MoshiConverterFactory
-import kotlin.coroutines.cancellation.CancellationException
 
-class MovieNetworkDataSource {
-    private val moshi = Moshi.Builder()
-        .add(KotlinJsonAdapterFactory())
-        .build()
-
-    private val movieApi: MovieApi = Retrofit.Builder()
-        .baseUrl(BuildConfig.BASE_TMDB_URL)
-        .addConverterFactory(MoshiConverterFactory.create(moshi))
-        .build()
-        .create(MovieApi::class.java)
-
-    suspend fun getNowPlayingMovies(): Result<List<NetworkMovie>> {
-        return try {
-            val response = movieApi.getNowPlayingMovies()
-            val moviePage = response.body()
-
-            when {
-                response.isSuccessful && moviePage != null -> {
-                    Log.d(TAG, "Now Playing Movie Fetch successful")
-                    Result.success(moviePage.results)
-                }
-                else -> {
-                    Result.failure(
-                        NetworkException(
-                            message = response.errorBody()?.string() ?: "Failed to get Now Playing Movies",
-                            responseCode = response.code(),
-                        )
-                    )
-                }
-            }
-        } catch (e: CancellationException) {
-            Log.e(TAG, "Get Now Playing Movies operation was canceled", e)
-            throw e
-        } catch (e: Exception) {
-            Log.e(TAG, "Failed to get Now Playing Movies", e)
-            Result.failure(e)
-        }
-    }
-
-    companion object {
-        private val TAG = MovieNetworkDataSource::class.java.simpleName
-    }
+interface MovieNetworkDataSource {
+    suspend fun getNowPlayingMovies(): Result<List<NetworkMovie>>
 }

--- a/app/src/main/java/com/jogasoft/moviefinder/di/NetworkModule.kt
+++ b/app/src/main/java/com/jogasoft/moviefinder/di/NetworkModule.kt
@@ -1,0 +1,36 @@
+package com.jogasoft.moviefinder.di
+
+import com.jogasoft.moviefinder.BuildConfig
+import com.jogasoft.moviefinder.data.source.network.MovieApi
+import com.squareup.moshi.Moshi
+import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import retrofit2.Retrofit
+import retrofit2.converter.moshi.MoshiConverterFactory
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+object NetworkModule {
+
+    @Singleton
+    @Provides
+    fun providesRetrofit(): Retrofit {
+        val moshi = Moshi.Builder()
+            .add(KotlinJsonAdapterFactory())
+            .build()
+
+        return Retrofit.Builder()
+            .baseUrl(BuildConfig.BASE_TMDB_URL)
+            .addConverterFactory(MoshiConverterFactory.create(moshi))
+            .build()
+    }
+
+    @Provides
+    fun providesMovieApi(retrofit: Retrofit): MovieApi {
+        return retrofit.create(MovieApi::class.java)
+    }
+}

--- a/app/src/main/java/com/jogasoft/moviefinder/di/RepositoryModule.kt
+++ b/app/src/main/java/com/jogasoft/moviefinder/di/RepositoryModule.kt
@@ -1,0 +1,18 @@
+package com.jogasoft.moviefinder.di
+
+import com.jogasoft.moviefinder.data.DefaultMovieRepository
+import com.jogasoft.moviefinder.data.MovieRepository
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class RepositoryModule {
+
+    @Singleton
+    @Binds
+    abstract fun bindMovieRepository(movieRepository: DefaultMovieRepository): MovieRepository
+}

--- a/app/src/main/java/com/jogasoft/moviefinder/ui/HomeActivity.kt
+++ b/app/src/main/java/com/jogasoft/moviefinder/ui/HomeActivity.kt
@@ -12,7 +12,9 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.jogasoft.moviefinder.ui.screen.HomeScreen
 import com.jogasoft.moviefinder.ui.theme.MovieFinderTheme
+import dagger.hilt.android.AndroidEntryPoint
 
+@AndroidEntryPoint
 class HomeActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)

--- a/app/src/main/java/com/jogasoft/moviefinder/ui/HomeViewModel.kt
+++ b/app/src/main/java/com/jogasoft/moviefinder/ui/HomeViewModel.kt
@@ -5,14 +5,18 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.jogasoft.moviefinder.data.Movie
 import com.jogasoft.moviefinder.data.MovieRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import javax.inject.Inject
 
-class HomeViewModel: ViewModel() {
-    private val movieRepository = MovieRepository()
+@HiltViewModel
+class HomeViewModel @Inject constructor(
+    private val movieRepository: MovieRepository
+): ViewModel() {
     private val exceptionHandler = CoroutineExceptionHandler { _, throwable ->
         Log.e("HomeViewModel", "Coroutine Failed", throwable)
     }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,8 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
     alias(libs.plugins.android.application) apply false
+    alias(libs.plugins.compose.compiler) apply false
     alias(libs.plugins.jetbrains.kotlin.android) apply false
+    alias(libs.plugins.hilt) apply false
+    alias(libs.plugins.ksp) apply false
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,9 +6,14 @@ coil = "2.7.0"
 composeBom = "2023.08.00"
 coreKtx = "1.13.1"
 espressoCore = "3.6.1"
+# Be careful when updating Hilt related depedency verions. Hilt KSP support is in alpha phase
+# making version compability very brittle.
+hilt = "2.51"
+hiltCompiler = "2.51"
 junit = "4.13.2"
 junitVersion = "1.2.1"
-kotlin = "1.9.0"
+kotlin = "2.0.0"
+ksp = "2.0.0-1.0.21"
 lifecycleRuntimeKtx = "2.8.4"
 lifecycleViewmodelCompose = "2.8.4"
 material = "1.12.0"
@@ -36,6 +41,10 @@ androidx-ui-tooling = { group = "androidx.compose.ui", name = "ui-tooling" }
 androidx-ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-tooling-preview" }
 androidx-material3 = { group = "androidx.compose.material3", name = "material3" }
 
+## Hilt
+hilt = { group = "com.google.dagger", name = "hilt-android", version.ref = "hilt"}
+hilt-compiler = { group = "com.google.dagger", name = "hilt-android-compiler", version.ref = "hiltCompiler"}
+
 # Retrofit & Moshi
 moshi = { group = "com.squareup.moshi", name = "moshi", version.ref = "moshi" }
 moshi-kotlin = { group = "com.squareup.moshi", name = "moshi-kotlin", version.ref = "moshi" }
@@ -51,5 +60,8 @@ androidx-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
+compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin"}
 jetbrains-kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
+hilt = { id = "com.google.dagger.hilt.android", version.ref = "hilt"}
+ksp = { id = "com.google.devtools.ksp", version.ref = "ksp"}
 


### PR DESCRIPTION
# Summary
This PR implements the Dagger Hilt dependency injection pattern. The following files have been converted to the Hilt pattern: MovieRepository.kt, MovieNetworkDataSource.kt, HomeViewModel.kt, and HomeActivity.kt. This establishes a consistent pattern for future classes of this type.

Additionally, this PR introduces the KSP annotation processor, which is currently used by Hilt but is expected to be used by other libraries in the future. It’s worth noting that Hilt via KSP is still in alpha, which makes the version compatibility somewhat brittle.

This PR also updates the Kotlin version to the latest supported version, 2.0.0, along with the Kotlin Compose Compiler plugin. This change eliminates the need to sync the Kotlin and Compose Compiler versions manually. For more details, refer to the [official documentation](https://developer.android.com/develop/ui/compose/compiler).