### PR TITLE
Feature: Add network paging to search implementation via Paging3 Library

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,14 @@
 name: Build and Test
 run-name: ${{ github.actor }} has triggered Main Workflow from a ${{ github.event_name }} event
-on: [ push, pull_request ]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ This Movie Finder Android app is designed as a sandbox environment for experimen
 
 ## Features
 - **Search Movies**: Search for movies by title with live suggestions.
+  - Supports pagination with infinite scroll
 - **Movie Categories**: Browse and view posters of the latest movies from TMDb's categories:
   - Now Playing
   - Popular
@@ -37,6 +38,7 @@ This project leverages the following libraries and tools:
 - [**Coil**](https://coil-kt.github.io/coil/) - An image loading library for Android backed by Kotlin Coroutines.
 - [**Kotlin Coroutines**](https://kotlinlang.org/docs/coroutines-overview.html) - Asynchronous programming support for Kotlin.
 - [**Navigation Component**](https://developer.android.com/guide/navigation) - Android Jetpack's framework for in-app navigation, integrated with Compose.
+- [**Paging 3**](https://developer.android.com/topic/libraries/architecture/paging/v3-overview) - Library for efficient data pagination in Android apps.
 - [**Material Design 3**](https://m3.material.io/) - Implements Material Design 3 (Material You) components in Compose.
 - [**JUnit**](https://junit.org/junit4/) - A widely-used testing framework for Java and Kotlin.
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -25,8 +25,8 @@ android {
         applicationId = "com.jogasoft.moviefinder"
         minSdk = 24
         targetSdk = 34
-        versionCode = 9
-        versionName = "0.0.9"
+        versionCode = 10
+        versionName = "0.0.10"
 
         testInstrumentationRunner = "com.jogasoft.moviefinder.MovieFinderHiltTestRunner"
         vectorDrawables {
@@ -109,6 +109,10 @@ dependencies {
     implementation(libs.androidx.navigation.compose)
     implementation(libs.androidx.hilt.navigation.compose)
 
+    // Paging
+    implementation(libs.androidx.paging)
+    implementation(libs.androidx.paging.compose)
+
     // Retrofit & Moshi
     implementation(libs.retrofit)
     implementation(libs.retrofit.moshi)
@@ -124,6 +128,7 @@ dependencies {
     testImplementation(libs.junit)
     testImplementation(libs.kotlin.coroutine.test)
     testImplementation(libs.kotlin.test)
+    testImplementation(libs.androidx.paging.test)
     androidTestImplementation(platform(libs.androidx.compose.bom))
     androidTestImplementation(libs.androidx.espresso.core)
     androidTestImplementation(libs.androidx.junit)

--- a/app/src/androidTest/java/com/jogasoft/moviefinder/ui/screen/SearchScreenTest.kt
+++ b/app/src/androidTest/java/com/jogasoft/moviefinder/ui/screen/SearchScreenTest.kt
@@ -3,13 +3,14 @@ package com.jogasoft.moviefinder.ui.screen
 import androidx.activity.ComponentActivity
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsNotDisplayed
-import androidx.compose.ui.test.isDisplayed
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
-import androidx.compose.ui.test.onAllNodesWithContentDescription
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
+import androidx.paging.PagingData
+import androidx.paging.compose.collectAsLazyPagingItems
 import com.jogasoft.moviefinder.R
-import com.jogasoft.moviefinder.ui.viewModel.SearchUiState
+import com.jogasoft.moviefinder.data.Movie
+import kotlinx.coroutines.flow.flowOf
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -21,9 +22,9 @@ class SearchScreenTest {
     @Before
     fun setUp() {
         rule.setContent { SearchScreen(
-            uiState =  SearchUiState(),
+            moviePagerItems = flowOf(PagingData.from(listOf<Movie>())).collectAsLazyPagingItems(),
             searchText = "",
-            navigateToMovieDetail = {},
+            navigateToMovieDetailAction = {},
             navigateBackAction = {},
             updateSearchTextAction = {}
         ) }

--- a/app/src/main/java/com/jogasoft/moviefinder/data/MovieRepository.kt
+++ b/app/src/main/java/com/jogasoft/moviefinder/data/MovieRepository.kt
@@ -1,13 +1,14 @@
 package com.jogasoft.moviefinder.data
 
+import androidx.paging.PagingData
 import kotlinx.coroutines.flow.Flow
 
 interface MovieRepository {
     fun observeMovies(): Flow<List<Movie>>
+    fun observePagedSearchedMovies(query: String):  Flow<PagingData<Movie>>
     suspend fun synchronizeNowPlayingMovies(): Result<Unit>
     suspend fun synchronizePopularMovies(): Result<Unit>
     suspend fun synchronizeTopRatedMovies(): Result<Unit>
     suspend fun synchronizeUpcomingMovies(): Result<Unit>
-    suspend fun getMoviesBySearchQuery(query: String): Result<List<Movie>>
     suspend fun getMovieDetailById(movieId: Int): Result<MovieDetail>
 }

--- a/app/src/main/java/com/jogasoft/moviefinder/data/source/network/DefaultMovieNetworkDataSource.kt
+++ b/app/src/main/java/com/jogasoft/moviefinder/data/source/network/DefaultMovieNetworkDataSource.kt
@@ -33,26 +33,29 @@ class DefaultMovieNetworkDataSource @Inject constructor(
         return getMovieListByType(MovieRequestType.UPCOMING)
     }
 
-    override suspend fun searchMovies(query: String): Result<List<NetworkMovie>> {
+    override suspend fun paginateSearchedMovies(
+        page: Int,
+        query: String
+    ): Result<NetworkMoviePage> {
         return try {
-            val response = movieApi.searchMovies(query)
-            val moviePage = response.body()
+            val response = movieApi.paginateSearchedMovies(page, query)
+            val networkMoviePage = response.body()
 
-            if (response.isSuccessful && moviePage != null) {
-                Result.success(moviePage.results)
+            if (response.isSuccessful && networkMoviePage != null) {
+                Result.success(networkMoviePage)
             } else {
                 Result.failure(
                     NetworkException(
-                        message = response.errorBody()?.string() ?: "Movie Search request failed",
+                        message = response.errorBody()?.string() ?: "Paged Movie Search request failed",
                         responseCode = response.code(),
                     )
                 )
             }
         } catch (e: CancellationException) {
-            Log.e(TAG, "Search Movies request operation was canceled", e)
+            Log.e(TAG, "Paged search Movies request operation was canceled", e)
             throw e
         } catch (e: Exception) {
-            Log.e(TAG, "Search Movies request failed", e)
+            Log.e(TAG, "Paged search Movies request failed", e)
             Result.failure(e)
         }
     }

--- a/app/src/main/java/com/jogasoft/moviefinder/data/source/network/MovieApi.kt
+++ b/app/src/main/java/com/jogasoft/moviefinder/data/source/network/MovieApi.kt
@@ -11,17 +11,20 @@ interface MovieApi {
     @GET("movie/now_playing")
     suspend fun getNowPlayingMovies(): Response<NetworkMoviePage>
 
-    @GET("movie/popular?language=en-US&page=1")
+    @GET("movie/popular")
     suspend fun getPopularMovies(): Response<NetworkMoviePage>
 
-    @GET("movie/top_rated?language=en-US&page=1")
+    @GET("movie/top_rated")
     suspend fun getTopRatedMovies(): Response<NetworkMoviePage>
 
-    @GET("movie/upcoming?language=en-US&page=1")
+    @GET("movie/upcoming")
     suspend fun getUpcomingMovies(): Response<NetworkMoviePage>
 
     @GET("search/movie")
-    suspend fun searchMovies(@Query("query") query: String): Response<NetworkMoviePage>
+    suspend fun paginateSearchedMovies(
+        @Query("page") page: Int,
+        @Query("query") query: String
+    ): Response<NetworkMoviePage>
 
     @GET("movie/{movieId}")
     suspend fun getMovieDetailById(@Path("movieId") movieId: Int): Response<NetworkMovieDetail>

--- a/app/src/main/java/com/jogasoft/moviefinder/data/source/network/MovieNetworkDataSource.kt
+++ b/app/src/main/java/com/jogasoft/moviefinder/data/source/network/MovieNetworkDataSource.kt
@@ -1,6 +1,7 @@
 package com.jogasoft.moviefinder.data.source.network
 
 import com.jogasoft.moviefinder.data.source.network.model.movie.NetworkMovie
+import com.jogasoft.moviefinder.data.source.network.model.movie.NetworkMoviePage
 import com.jogasoft.moviefinder.data.source.network.model.movieDetail.NetworkMovieDetail
 
 interface MovieNetworkDataSource {
@@ -8,6 +9,6 @@ interface MovieNetworkDataSource {
     suspend fun getPopularMovies(): Result<List<NetworkMovie>>
     suspend fun getTopRatedMovies(): Result<List<NetworkMovie>>
     suspend fun getUpcomingMovies(): Result<List<NetworkMovie>>
-    suspend fun searchMovies(query: String): Result<List<NetworkMovie>>
+    suspend fun paginateSearchedMovies(page: Int, query: String): Result<NetworkMoviePage>
     suspend fun getMovieDetailById(movieId: Int): Result<NetworkMovieDetail>
 }

--- a/app/src/main/java/com/jogasoft/moviefinder/data/source/network/SearchMoviePagingSource.kt
+++ b/app/src/main/java/com/jogasoft/moviefinder/data/source/network/SearchMoviePagingSource.kt
@@ -1,0 +1,43 @@
+package com.jogasoft.moviefinder.data.source.network
+
+import androidx.paging.PagingSource
+import androidx.paging.PagingState
+import com.jogasoft.moviefinder.data.source.network.model.movie.NetworkMovie
+import kotlin.coroutines.cancellation.CancellationException
+import kotlin.random.Random
+
+class SearchMoviePagingSource(
+    private val movieNetworkDataSource: MovieNetworkDataSource,
+    private val query: String
+): PagingSource<Int, NetworkMovie>() {
+    override suspend fun load(params: LoadParams<Int>): LoadResult<Int, NetworkMovie> {
+        try {
+            val nextPageNumber = params.key ?: 1
+            movieNetworkDataSource.paginateSearchedMovies(nextPageNumber, query).fold(
+                onSuccess = { networkMoviePage ->
+                    val networkMovies = networkMoviePage.results
+                    return LoadResult.Page(
+                        data = networkMovies,
+                        prevKey = null,
+                        nextKey = if (networkMovies.isNotEmpty()) networkMoviePage.page + 1 else null
+                    )
+                },
+                onFailure = { e ->
+                    return LoadResult.Error(e)
+                }
+            )
+            //todo revist cancellation exception here
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            return LoadResult.Error(e)
+        }
+    }
+
+    override fun getRefreshKey(state: PagingState<Int, NetworkMovie>): Int? {
+        return state.anchorPosition?.let { anchorPosition ->
+            val anchorPage = state.closestPageToPosition(anchorPosition)
+            anchorPage?.prevKey?.plus(1) ?: anchorPage?.nextKey?.minus(1)
+        }
+    }
+}

--- a/app/src/main/java/com/jogasoft/moviefinder/ui/navigation/Navigation.kt
+++ b/app/src/main/java/com/jogasoft/moviefinder/ui/navigation/Navigation.kt
@@ -8,6 +8,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
+import androidx.paging.compose.collectAsLazyPagingItems
 import com.jogasoft.moviefinder.ui.viewModel.HomeViewModel
 import com.jogasoft.moviefinder.ui.viewModel.MovieDetailViewModel
 import com.jogasoft.moviefinder.ui.screen.HomeScreen
@@ -61,11 +62,11 @@ fun MovieFinderAppNavigationHost(navController: NavHostController) {
         composable<SearchScreen> {
             val viewModel = hiltViewModel<SearchViewModel>()
             SearchScreen(
-                uiState = viewModel.uiState.collectAsStateWithLifecycle().value,
+                moviePagerItems = viewModel.moviePagerState.collectAsLazyPagingItems(),
                 searchText = viewModel.searchTextState.collectAsStateWithLifecycle().value,
                 updateSearchTextAction = viewModel::updateSearchText,
                 navigateBackAction = { navController.popBackStack() },
-                navigateToMovieDetail = { movieId ->
+                navigateToMovieDetailAction = { movieId ->
                     navController.navigate(MovieDetailScreen(movieId))
                 }
             )

--- a/app/src/main/java/com/jogasoft/moviefinder/ui/viewModel/SearchViewModel.kt
+++ b/app/src/main/java/com/jogasoft/moviefinder/ui/viewModel/SearchViewModel.kt
@@ -2,20 +2,22 @@ package com.jogasoft.moviefinder.ui.viewModel
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.jogasoft.moviefinder.data.Movie
+import androidx.paging.PagingData
 import com.jogasoft.moviefinder.data.MovieRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
-import kotlinx.coroutines.launch
 import javax.inject.Inject
 
-@OptIn(FlowPreview::class)
+@OptIn(FlowPreview::class, ExperimentalCoroutinesApi::class)
 @HiltViewModel
 class SearchViewModel @Inject constructor(
     private val movieRepository: MovieRepository
@@ -23,41 +25,18 @@ class SearchViewModel @Inject constructor(
     private var _searchTextState = MutableStateFlow("")
     val searchTextState = _searchTextState.asStateFlow()
 
-    private var _uiState = MutableStateFlow(SearchUiState())
-    val uiState = _uiState.asStateFlow()
-
-    init {
-        viewModelScope.launch {
-            _searchTextState.debounce(500)
-                .filter { it.isNotBlank() }
-                .collectLatest {
-                    searchMovies()
-                }
+    val moviePagerState = _searchTextState.debounce(500L)
+        .filter { it.isNotBlank() } // prevents unnecessary network request when query is empty string
+        .flatMapLatest { query ->
+            movieRepository.observePagedSearchedMovies(query)
         }
-    }
+        .stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.WhileSubscribed(5000),
+            initialValue = PagingData.empty()
+        )
 
     fun updateSearchText(text: String) {
         _searchTextState.update { text }
     }
-
-    private fun searchMovies() {
-        viewModelScope.launch {
-            movieRepository.getMoviesBySearchQuery(_searchTextState.value).fold(
-                onSuccess = { movies ->
-                    _uiState.update {
-                        it.copy(
-                            movies = movies
-                        )
-                    }
-                },
-                onFailure = {
-
-                }
-            )
-        }
-    }
 }
-
-data class SearchUiState(
-    val movies: List<Movie> = listOf()
-)

--- a/app/src/test/java/com/jogasoft/moviefinder/data/DefaultMovieRepositoryTest.kt
+++ b/app/src/test/java/com/jogasoft/moviefinder/data/DefaultMovieRepositoryTest.kt
@@ -3,6 +3,7 @@ package com.jogasoft.moviefinder.data
 import com.jogasoft.moviefinder.data.source.local.FakeMovieDao
 import com.jogasoft.moviefinder.data.source.network.FakeMovieNetworkDataSource
 import com.jogasoft.moviefinder.data.source.network.model.movie.NetworkMovie
+import com.jogasoft.moviefinder.data.source.network.model.movie.NetworkMoviePage
 import com.jogasoft.moviefinder.data.source.network.model.movieDetail.NetworkBelongsToCollection
 import com.jogasoft.moviefinder.data.source.network.model.movieDetail.NetworkGenre
 import com.jogasoft.moviefinder.data.source.network.model.movieDetail.NetworkMovieDetail
@@ -36,6 +37,13 @@ class DefaultMovieRepositoryTest {
             voteCount = 155
         )
     }
+
+    private val networkMoviePage = NetworkMoviePage(
+        page = 1,
+        results = networkMovies,
+        totalPages = 1,
+        totalResults = networkMovies.size
+    )
 
     private val movieDetailId = 1
     private val movieDetail = NetworkMovieDetail(
@@ -91,7 +99,7 @@ class DefaultMovieRepositoryTest {
     )
 
     private val movieNetworkDataSource = FakeMovieNetworkDataSource(
-        networkMovies = networkMovies,
+        networkMoviePage = networkMoviePage,
         networkMovieDetail = movieDetail
     )
 
@@ -125,7 +133,7 @@ class DefaultMovieRepositoryTest {
 
         val synchronizedMovieList = movieRepository.observeMovies().first()
         assertTrue(synchronizedMovieList.isNotEmpty())
-        assertTrue(synchronizedMovieList.all { it.category == MovieCategory.NOW_PLAYING  })
+        assertTrue(synchronizedMovieList.all { it.category == MovieCategory.NOW_PLAYING })
     }
 
     @Test
@@ -151,7 +159,7 @@ class DefaultMovieRepositoryTest {
 
         val synchronizedMovieList = movieRepository.observeMovies().first()
         assertTrue(synchronizedMovieList.isNotEmpty())
-        assertTrue(synchronizedMovieList.all { it.category == MovieCategory.POPULAR  })
+        assertTrue(synchronizedMovieList.all { it.category == MovieCategory.POPULAR })
     }
 
     @Test
@@ -177,7 +185,7 @@ class DefaultMovieRepositoryTest {
 
         val synchronizedMovieList = movieRepository.observeMovies().first()
         assertTrue(synchronizedMovieList.isNotEmpty())
-        assertTrue(synchronizedMovieList.all { it.category == MovieCategory.TOP_RATED  })
+        assertTrue(synchronizedMovieList.all { it.category == MovieCategory.TOP_RATED })
     }
 
     @Test
@@ -203,7 +211,7 @@ class DefaultMovieRepositoryTest {
 
         val synchronizedMovieList = movieRepository.observeMovies().first()
         assertTrue(synchronizedMovieList.isNotEmpty())
-        assertTrue(synchronizedMovieList.all { it.category == MovieCategory.UPCOMING  })
+        assertTrue(synchronizedMovieList.all { it.category == MovieCategory.UPCOMING })
     }
 
     @Test

--- a/app/src/test/java/com/jogasoft/moviefinder/data/FakeMovieRepository.kt
+++ b/app/src/test/java/com/jogasoft/moviefinder/data/FakeMovieRepository.kt
@@ -1,5 +1,9 @@
 package com.jogasoft.moviefinder.data
 
+import androidx.paging.Pager
+import androidx.paging.PagingConfig
+import androidx.paging.PagingData
+import androidx.paging.testing.asPagingSourceFactory
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 
@@ -10,15 +14,20 @@ class FakeMovieRepository(
     private val _movies = MutableSharedFlow<List<Movie>>()
     suspend fun emit(movies: List<Movie>) = _movies.emit(movies)
     override fun observeMovies(): Flow<List<Movie>> = _movies
+    override fun observePagedSearchedMovies(query: String): Flow<PagingData<Movie>> {
+        return Pager(
+            config = PagingConfig(
+                pageSize = 20,
+                prefetchDistance = 3
+            ),
+            initialKey = null,
+            pagingSourceFactory =  movieList.asPagingSourceFactory()
+        ).flow
+    }
 
     override suspend fun synchronizeNowPlayingMovies(): Result<Unit> = Result.success(Unit)
     override suspend fun synchronizePopularMovies(): Result<Unit> = Result.success(Unit)
     override suspend fun synchronizeTopRatedMovies(): Result<Unit> = Result.success(Unit)
     override suspend fun synchronizeUpcomingMovies(): Result<Unit> = Result.success(Unit)
-    override suspend fun getMoviesBySearchQuery(query: String): Result<List<Movie>> {
-        val filteredMovies = movieList.filter { it.title.contains(query) }
-        return Result.success(filteredMovies)
-    }
-
     override suspend fun getMovieDetailById(movieId: Int): Result<MovieDetail>  = Result.success(movieDetail)
 }

--- a/app/src/test/java/com/jogasoft/moviefinder/data/source/network/DefaultMovieNetworkDataSourceTest.kt
+++ b/app/src/test/java/com/jogasoft/moviefinder/data/source/network/DefaultMovieNetworkDataSourceTest.kt
@@ -205,25 +205,37 @@ class DefaultMovieNetworkDataSourceTest {
     @Test
     fun searchMovies_returnsSuccess_withExpectedResult() = runTest {
         val searchQuery = "a"
-        val response = movieNetworkDataSource.searchMovies(searchQuery)
+        val response = movieNetworkDataSource.paginateSearchedMovies(
+            networkMoviePage.page,
+            searchQuery
+        )
+
         assertEquals(
-            networkMoviePage.results.filter { it.title.contains(searchQuery) },
+            networkMoviePage,
             response.getOrNull()
         )
     }
 
     @Test
     fun searchMovies_returnsFailure_withExpectedResult() = runTest {
+        val searchQuery = "a"
         movieApi.shouldReturnErrorResponse = true
-        val response = movieNetworkDataSource.searchMovies("a")
+        val response = movieNetworkDataSource.paginateSearchedMovies(
+            networkMoviePage.page,
+            searchQuery
+        )
         assertTrue(response.isFailure)
     }
 
     @Test
     fun searchMovies_throwsCancellationException_whenCancelled() = runTest {
+        val searchQuery = "a"
         movieApi.shouldThrowCancellationException = true
         assertFailsWith<CancellationException> {
-            movieNetworkDataSource.searchMovies("a")
+            movieNetworkDataSource.paginateSearchedMovies(
+                networkMoviePage.page,
+                searchQuery
+            )
         }
     }
 

--- a/app/src/test/java/com/jogasoft/moviefinder/data/source/network/FakeMovieApi.kt
+++ b/app/src/test/java/com/jogasoft/moviefinder/data/source/network/FakeMovieApi.kt
@@ -28,19 +28,14 @@ class FakeMovieApi(
 
     override suspend fun getUpcomingMovies(): Response<NetworkMoviePage> = getMovies()
 
-    override suspend fun searchMovies(query: String): Response<NetworkMoviePage> {
+    override suspend fun paginateSearchedMovies(
+        page: Int,
+        query: String
+    ): Response<NetworkMoviePage> {
         return when {
             shouldThrowCancellationException -> throw CancellationException("Simulated Cancellation")
             shouldReturnErrorResponse -> Response.error(500, null)
-            else -> {
-                val filteredResults = networkMoviePage.results.filter { it.title.contains(query) }
-                val filteredNetworkMoviePage = networkMoviePage.copy(
-                    results =  filteredResults,
-                    totalResults = filteredResults.size
-                )
-
-                return Response.success(filteredNetworkMoviePage)
-            }
+            else -> Response.success(networkMoviePage)
         }
     }
 

--- a/app/src/test/java/com/jogasoft/moviefinder/data/source/network/FakeMovieNetworkDataSource.kt
+++ b/app/src/test/java/com/jogasoft/moviefinder/data/source/network/FakeMovieNetworkDataSource.kt
@@ -1,10 +1,11 @@
 package com.jogasoft.moviefinder.data.source.network
 
 import com.jogasoft.moviefinder.data.source.network.model.movie.NetworkMovie
+import com.jogasoft.moviefinder.data.source.network.model.movie.NetworkMoviePage
 import com.jogasoft.moviefinder.data.source.network.model.movieDetail.NetworkMovieDetail
 
 class FakeMovieNetworkDataSource(
-    private val networkMovies: List<NetworkMovie>,
+    private val networkMoviePage: NetworkMoviePage,
     private val networkMovieDetail: NetworkMovieDetail
 ): MovieNetworkDataSource {
     var shouldReturnFailureResult = false
@@ -12,35 +13,38 @@ class FakeMovieNetworkDataSource(
     override suspend fun getNowPlayingMovies(): Result<List<NetworkMovie>> {
         return when {
             shouldReturnFailureResult -> Result.failure(Exception())
-            else -> Result.success(networkMovies)
+            else -> Result.success(networkMoviePage.results)
         }
     }
 
     override suspend fun getPopularMovies(): Result<List<NetworkMovie>> {
         return when {
             shouldReturnFailureResult -> Result.failure(Exception())
-            else -> Result.success(networkMovies)
+            else -> Result.success(networkMoviePage.results)
         }
     }
 
     override suspend fun getTopRatedMovies(): Result<List<NetworkMovie>> {
         return when {
             shouldReturnFailureResult -> Result.failure(Exception())
-            else -> Result.success(networkMovies)
+            else -> Result.success(networkMoviePage.results)
         }
     }
 
     override suspend fun getUpcomingMovies(): Result<List<NetworkMovie>> {
         return when {
             shouldReturnFailureResult -> Result.failure(Exception())
-            else -> Result.success(networkMovies)
+            else -> Result.success(networkMoviePage.results)
         }
     }
 
-    override suspend fun searchMovies(query: String): Result<List<NetworkMovie>> {
+    override suspend fun paginateSearchedMovies(
+        page: Int,
+        query: String
+    ): Result<NetworkMoviePage> {
         return when {
             shouldReturnFailureResult -> Result.failure(Exception())
-            else -> Result.success(networkMovies)
+            else -> Result.success(networkMoviePage)
         }
     }
 

--- a/app/src/test/java/com/jogasoft/moviefinder/data/source/network/SearchMoviePagingSourceTest.kt
+++ b/app/src/test/java/com/jogasoft/moviefinder/data/source/network/SearchMoviePagingSourceTest.kt
@@ -124,7 +124,6 @@ class SearchMoviePagingSourceTest {
             pagingSource = pagingSource
         )
 
-        pager.append()
         val result = pager.refresh() as PagingSource.LoadResult.Page
 
         assertEquals(result.data, networkMoviePage.results)

--- a/app/src/test/java/com/jogasoft/moviefinder/data/source/network/SearchMoviePagingSourceTest.kt
+++ b/app/src/test/java/com/jogasoft/moviefinder/data/source/network/SearchMoviePagingSourceTest.kt
@@ -1,0 +1,151 @@
+package com.jogasoft.moviefinder.data.source.network
+
+import androidx.paging.PagingConfig
+import androidx.paging.PagingSource
+import androidx.paging.testing.TestPager
+import com.jogasoft.moviefinder.data.source.network.model.movie.NetworkMovie
+import com.jogasoft.moviefinder.data.source.network.model.movie.NetworkMoviePage
+import com.jogasoft.moviefinder.data.source.network.model.movieDetail.NetworkBelongsToCollection
+import com.jogasoft.moviefinder.data.source.network.model.movieDetail.NetworkGenre
+import com.jogasoft.moviefinder.data.source.network.model.movieDetail.NetworkMovieDetail
+import com.jogasoft.moviefinder.data.source.network.model.movieDetail.NetworkProductionCompany
+import com.jogasoft.moviefinder.data.source.network.model.movieDetail.NetworkProductionCountry
+import com.jogasoft.moviefinder.data.source.network.model.movieDetail.NetworkSpokenLanguage
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Test
+import kotlin.random.Random
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class SearchMoviePagingSourceTest {
+    private val networkMovies = List(10) { index ->
+        NetworkMovie(
+            id = index,
+            adult = Random.nextBoolean(),
+            backdropPath = "backdropPath.png",
+            genreIds = listOf(),
+            originalLanguage = "test language",
+            originalTitle = " test original title",
+            overview = "test overview",
+            popularity = 1.0,
+            posterPath = "posterPath.png",
+            releaseDate = "2024-12-12",
+            title = "fake title",
+            video = false,
+            voteAverage = 2.0,
+            voteCount = 155
+        )
+    }
+
+    private val networkMoviePage = NetworkMoviePage(
+        page = 1,
+        results = networkMovies,
+        totalPages = 1,
+        totalResults = networkMovies.size
+    )
+
+    private val movieDetailId = 1
+    private val movieDetail = NetworkMovieDetail(
+        id = movieDetailId,
+        adult = false,
+        backdropPath = "Test Path",
+        belongsToCollection = NetworkBelongsToCollection(
+            id = 1,
+            name = "Test Name",
+            posterPath = "Test Path",
+            backdropPath = "Test Path"
+        ),
+        budget = 200000000,
+        genres = listOf(NetworkGenre(id = 1, name = "Action")),
+        homepage = "www.test.com",
+        imdbId = "1",
+        originCountry = listOf("US"),
+        originalLanguage = "en",
+        originalTitle = "Test Title",
+        overview = "Test Overview",
+        popularity = 1.0,
+        posterPath = "Test Path",
+        productionCompanies = listOf(
+            NetworkProductionCompany(
+                id = 1,
+                logoPath = "Test Path",
+                name = "Test Name",
+                originCountry = "US"
+            ),
+        ),
+        productionCountries = listOf(
+            NetworkProductionCountry(
+                iso_3166_1 = "US",
+                name = "United States of America"
+            )
+        ),
+        releaseDate = "2024-07-24",
+        revenue = 100,
+        runtime = 1,
+        spokenLanguages = listOf(
+            NetworkSpokenLanguage(
+                englishName = "English",
+                iso_639_1 = "en",
+                name = "English"
+            )
+        ),
+        status = "Test Status",
+        tagline = "Test TagLine",
+        title = "Test Title",
+        video = false,
+        voteAverage = 1.0,
+        voteCount = 1
+    )
+
+    private val movieNetworkDataSource = FakeMovieNetworkDataSource(
+        networkMoviePage = networkMoviePage,
+        networkMovieDetail = movieDetail
+    )
+
+    private lateinit var pagingSource: SearchMoviePagingSource
+
+    @Before
+    fun setUp() {
+        pagingSource = SearchMoviePagingSource(
+            movieNetworkDataSource = movieNetworkDataSource,
+            query = ""
+        )
+    }
+
+    @Test
+    fun returns_successfulPageLoad_with_expectedData() = runTest {
+        val pager = TestPager(
+            config = PagingConfig(
+                pageSize = 20,
+                prefetchDistance = 3
+            ),
+            pagingSource = pagingSource
+        )
+
+        pager.append()
+        val result = pager.refresh() as PagingSource.LoadResult.Page
+
+        assertEquals(result.data, networkMoviePage.results)
+    }
+
+    @Test
+    fun returns_error_properly() = runTest {
+        movieNetworkDataSource.shouldReturnFailureResult = true
+
+        val pager = TestPager(
+            config = PagingConfig(
+                pageSize = 20,
+                prefetchDistance = 3
+            ),
+            pagingSource = pagingSource
+        )
+
+        val result = pager.refresh()
+        assertTrue(result is PagingSource.LoadResult.Error)
+
+        val page = pager.getLastLoadedPage()
+        assertNull(page)
+    }
+}

--- a/app/src/test/java/com/jogasoft/moviefinder/ui/viewModel/SearchViewModelTest.kt
+++ b/app/src/test/java/com/jogasoft/moviefinder/ui/viewModel/SearchViewModelTest.kt
@@ -63,15 +63,6 @@ class SearchViewModelTest {
     }
 
     @Test
-    fun initializes_uiState_with_correct_values() = runTest {
-        val uiState = SearchUiState()
-        assertEquals(listOf(), uiState.movies)
-        
-        val uiStateFlow = searchViewModel.uiState.value
-        assertEquals(listOf(), uiStateFlow.movies)
-    }
-
-    @Test
     fun initializes_searchTextState_with_correct_values() = runTest {
         val searchTextState = searchViewModel.searchTextState.value
         assertEquals("", searchTextState)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -21,6 +21,7 @@ lifecycleViewmodelCompose = "2.8.4"
 material = "1.12.0"
 moshi = "1.13.0"
 navigation = "2.8.0-rc01"
+paging = "3.3.2"
 retrofit = "2.11.0"
 room = "2.6.1"
 
@@ -50,10 +51,14 @@ androidx-material3 = { group = "androidx.compose.material3", name = "material3" 
 hilt = { group = "com.google.dagger", name = "hilt-android", version.ref = "hilt"}
 hilt-compiler = { group = "com.google.dagger", name = "hilt-android-compiler", version.ref = "hiltCompiler"}
 
-#Navigation
+# Navigation
 androidx-navigation-compose = { group = "androidx.navigation", name = "navigation-compose", version.ref = "navigation"}
 androidx-hilt-navigation-compose = { group = "androidx.hilt", name = "hilt-navigation-compose", version.ref = "hiltNavigation"}
 androidx-navigation-testing = { group = "androidx.navigation", name = "navigation-testing", version.ref = "navigation"}
+
+# Paging
+androidx-paging = { group = "androidx.paging", name = "paging-runtime", version.ref = "paging"}
+androidx-paging-compose = { group = "androidx.paging", name = "paging-compose", version.ref = "paging"}
 
 # Retrofit & Moshi
 moshi = { group = "com.squareup.moshi", name = "moshi", version.ref = "moshi" }
@@ -67,12 +72,13 @@ room-compiler = { group = "androidx.room", name = "room-compiler", version.ref =
 room-ktx = { group = "androidx.room", name = "room-ktx", version.ref = "room"}
 
 # Testing
-junit = { group = "junit", name = "junit", version.ref = "junit" }
-androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "junitVersion" }
 androidx-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espressoCore" }
+androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "junitVersion" }
+androidx-paging-test = { group = "androidx.paging", name = "paging-testing", version.ref = "paging"}
 androidx-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest" }
 androidx-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
 hilt-testing = { group = "com.google.dagger", name = "hilt-android-testing", version.ref = "hilt"}
+junit = { group = "junit", name = "junit", version.ref = "junit" }
 
 kotlin-coroutine-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test" }
 kotlin-test = { group = "org.jetbrains.kotlin", name = "kotlin-test" }


### PR DESCRIPTION
# Summary
This PR introduces paging functionality to the search feature of the Movie Finder app using the Paging 3 library. The search results now load in a paginated manner, improving performance and user experience when dealing with large datasets. Currently, the paging implementation retrieves data directly from the network and does not utilize the local database since search queries change frequently.

## Notable Changes
- Pagination
  - Paging3 library introduced
  - Tests added for pagination
  - SearchViewModel.kt / SearchScreen.kt
    - Utilizes Paging Data flow to render movies
- README
  - Adds documentation for paging3 library inclusion and infinite scroll feature. 

## Screenshots
![Sep-10-2024 21-06-41](https://github.com/user-attachments/assets/96f067dc-3eb9-4920-a849-dd9b03fd0efb)
