### PR TITLE
Improvement: Add version code check to main github workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,7 +46,7 @@ jobs:
           echo "version_main=${VERSION_MAIN}" >> $GITHUB_ENV
       - name: Compare ${{ github.ref }} branch and Main branch versions
         run: |
-          if [ "$VERSION_PR" -le "$VERSION_MAIN" ]; then
+          if [ "$VERSION_PR" -l "$VERSION_MAIN" ]; then
             echo "VersionCode on PR branch ${VERSION_PR} is not greater than on the main branch ${VERSION_MAIN}."
             exit 1
           else

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -50,7 +50,7 @@ jobs:
             echo "VersionCode on PR branch ($version_pr) is not greater than on the main branch ($version_main)."
             exit 1
           else
-            echo "VersionCode on PR branch is greater than on the main branch."
+            echo "VersionCode on PR branch ($version_pr) is greater than on the main branch ($version_main)."
           fi
   unit-test:
     needs: build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,6 +33,8 @@ jobs:
     steps:
       - name: Checkout and clone repository branch ${{ github.ref }}
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # Fetch the entire history, including all branches
       - name: Extract version code from Pull Request branch ${{ github.ref }}
         run: |
           VERSION_PR=$(grep -oP '(?<=versionCode = )\d+' app/build.gradle.kts)

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,6 +28,28 @@ jobs:
       - name: Build with Gradle
         run: ./gradlew build
       - run: echo "The build job's status is ${{ job.status }}."
+  check-version-code:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout and clone repository branch ${{ github.ref }}
+        uses: actions/checkout@v4
+      - name: Extract version code from Pull Request branch ${{ github.ref }}
+        run: |
+          VERSION_PR=$(grep -oP '(?<=versionCode = )\d+' app/build.gradle.kts)
+          echo "version_pr=${VERSION_PR}" >> $GITHUB_ENV
+      - name: Extract version code from Main branch
+        run: |
+          git checkout main
+          VERSION_MAIN=$(grep -op '(?<=versionCode = )\d+' app/build.gradle.kts)
+          echo "version_main=${VERSION_MAIN}" >> $GITHUB_ENV
+      - name: Compare ${{ github.ref }} branch and Main branch versions
+        run: |
+          if [ ${{ env.version_pr }} -le ${{ env.version_main }} ]; then
+            echo "VersionCode on PR branch (${env.version_pr}) is not greater than on the main branch (${env.version_main})."
+            exit 1
+          else
+            echo "VersionCode on PR branch is greater than on the main branch."
+          fi
   unit-test:
     needs: build
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,7 +46,7 @@ jobs:
           echo "version_main=${VERSION_MAIN}" >> $GITHUB_ENV
       - name: Compare ${{ github.ref }} branch and Main branch versions
         run: |
-          if [ "$version_pr" -l "$version_main" ]; then
+          if [ "$version_pr" -le "$version_main" ]; then
             echo "VersionCode on PR branch ($version_pr) is not greater than on the main branch ($version_main)."
             exit 1
           else

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,7 +46,7 @@ jobs:
           echo "version_main=${VERSION_MAIN}" >> $GITHUB_ENV
       - name: Compare ${{ github.ref }} branch and Main branch versions
         run: |
-          if [ "${VERSION_PR}" -le "${VERSION_MAIN}" ]; then
+          if [ "$VERSION_PR" -le "$VERSION_MAIN" ]; then
             echo "VersionCode on PR branch ${VERSION_PR} is not greater than on the main branch ${VERSION_MAIN}."
             exit 1
           else

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Extract version code from Main branch
         run: |
           git checkout main
-          VERSION_MAIN=$(grep -op '(?<=versionCode = )\d+' app/build.gradle.kts)
+          VERSION_MAIN=$(grep -oP '(?<=versionCode = )\d+' app/build.gradle.kts)
           echo "version_main=${VERSION_MAIN}" >> $GITHUB_ENV
       - name: Compare ${{ github.ref }} branch and Main branch versions
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,8 +46,8 @@ jobs:
           echo "version_main=${VERSION_MAIN}" >> $GITHUB_ENV
       - name: Compare ${{ github.ref }} branch and Main branch versions
         run: |
-          if [ "$VERSION_PR" -l "$VERSION_MAIN" ]; then
-            echo "VersionCode on PR branch ${VERSION_PR} is not greater than on the main branch ${VERSION_MAIN}."
+          if [ "version_pr" -l "$version_main" ]; then
+            echo "VersionCode on PR branch ($version_pr) is not greater than on the main branch ($version_main)."
             exit 1
           else
             echo "VersionCode on PR branch is greater than on the main branch."

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,8 +46,8 @@ jobs:
           echo "version_main=${VERSION_MAIN}" >> $GITHUB_ENV
       - name: Compare ${{ github.ref }} branch and Main branch versions
         run: |
-          if [ ${{ env.version_pr }} -le ${{ env.version_main }} ]; then
-            echo "VersionCode on PR branch (${env.version_pr}) is not greater than on the main branch (${env.version_main})."
+          if [ "${VERSION_PR}" -le "${VERSION_MAIN}" ]; then
+            echo "VersionCode on PR branch ${VERSION_PR} is not greater than on the main branch ${VERSION_MAIN}."
             exit 1
           else
             echo "VersionCode on PR branch is greater than on the main branch."

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,7 +46,7 @@ jobs:
           echo "version_main=${VERSION_MAIN}" >> $GITHUB_ENV
       - name: Compare ${{ github.ref }} branch and Main branch versions
         run: |
-          if [ "version_pr" -l "$version_main" ]; then
+          if [ "$version_pr" -l "$version_main" ]; then
             echo "VersionCode on PR branch ($version_pr) is not greater than on the main branch ($version_main)."
             exit 1
           else

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -25,8 +25,8 @@ android {
         applicationId = "com.jogasoft.moviefinder"
         minSdk = 24
         targetSdk = 34
-        versionCode = 11
-        versionName = "0.0.11"
+        versionCode = 12
+        versionName = "0.0.12"
 
         testInstrumentationRunner = "com.jogasoft.moviefinder.MovieFinderHiltTestRunner"
         vectorDrawables {


### PR DESCRIPTION
# Summary
This PR updates the GitHub workflow to enforce version control on pull requests. Specifically, it requires that any PR must have a versionCode greater than or equal to the versionCode of the main branch before it can be merged. This ensures proper version management and avoids conflicts or downgrades when merging changes.

# Notable Changes
- .github/workflows/main.yml
  - Added a new job that automatically compares the versionCode of the PR branch with the versionCode of the main branch. If the PR branch’s versionCode is not greater than or equal to the main branch’s versionCode, the workflow will prevent the PR from being merged.